### PR TITLE
Add GPT-OSS chat demo with Flask backend and React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# GPT-OSS Chat Demo
+
+This example provides a minimal chat application that talks to a locally running GPT-OSS model via a Flask backend and a React frontend built with Vite.
+
+## Prerequisites
+- [Ollama](https://ollama.com/) installed
+- Pull the model:
+  ```bash
+  ollama pull gpt-oss:20b
+  ```
+
+## Backend (Flask)
+1. Install dependencies and start the server:
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   python app.py
+   ```
+   The backend listens on `http://localhost:5000` and forwards requests to `http://localhost:11434`.
+
+## Frontend (React + Vite)
+1. Install dependencies and run the dev server:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+   The app will be available at `http://localhost:5173` and will call the backend for responses.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,28 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from openai import OpenAI
+
+app = Flask(__name__)
+CORS(app)
+
+client = OpenAI(
+    base_url='http://localhost:11434/v1',
+    api_key='ollama',
+)
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    user_message = request.json.get('message')
+    if not user_message:
+        return jsonify({'error': 'Message is required'}), 400
+    try:
+        response = client.chat.completions.create(
+            model='gpt-oss:20b',
+            messages=[{'role': 'user', 'content': user_message}],
+        )
+        return jsonify({'reply': response.choices[0].message['content']})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(debug=True, port=5000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+flask
+openai
+flask-cors
+python-dotenv

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GPT-OSS Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "chat-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,61 @@
+.App {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100%;
+  max-width: 600px;
+  margin: auto;
+  border: 1px solid #ccc;
+  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+.chat-window {
+  flex-grow: 1;
+  padding: 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.message {
+  padding: 10px 15px;
+  border-radius: 18px;
+  max-width: 80%;
+  word-wrap: break-word;
+}
+
+.user {
+  background-color: #007bff;
+  color: white;
+  align-self: flex-end;
+}
+
+.bot {
+  background-color: #f1f0f0;
+  color: black;
+  align-self: flex-start;
+}
+
+.chat-input {
+  display: flex;
+  padding: 10px;
+  border-top: 1px solid #ccc;
+}
+
+.chat-input input {
+  flex-grow: 1;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  padding: 10px;
+  margin-right: 10px;
+}
+
+.chat-input button {
+  border: none;
+  background-color: #007bff;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 20px;
+  cursor: pointer;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react'
+import './App.css'
+
+function App() {
+  const [input, setInput] = useState('')
+  const [messages, setMessages] = useState([
+    { text: 'Hello! How can I help you today?', sender: 'bot' }
+  ])
+
+  const handleSend = async () => {
+    if (input.trim()) {
+      const userMessage = { text: input, sender: 'user' }
+      setMessages(prev => [...prev, userMessage])
+
+      const response = await fetch('http://localhost:5000/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: input })
+      })
+      const data = await response.json()
+      const botMessage = { text: data.reply, sender: 'bot' }
+      setMessages(prev => [...prev, botMessage])
+      setInput('')
+    }
+  }
+
+  return (
+    <div className="App">
+      <div className="chat-window">
+        {messages.map((msg, index) => (
+          <div key={index} className={`message ${msg.sender}`}>
+            {msg.text}
+          </div>
+        ))}
+      </div>
+      <div className="chat-input">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyPress={(e) => e.key === 'Enter' && handleSend()}
+          placeholder="Type a message..."
+        />
+        <button onClick={handleSend}>Send</button>
+      </div>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+})


### PR DESCRIPTION
## Summary
- replace previous Express server with a Flask backend that proxies chat requests to a local Ollama instance
- rewrite React component to call the Flask endpoint and include basic chat styling
- update README with setup instructions for the Flask backend and Vite-powered React frontend

## Testing
- ❌ `pip install -r backend/requirements.txt` (ERROR: Could not find a version that satisfies the requirement flask)
- ✅ `python -m py_compile backend/app.py`
- ❌ `npm install` (403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)
- ❌ `npm run build` (sh: 1: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68adffba3af08326891a569e7a903a1b