### PR TITLE
feat: add weather card support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,28 +1,165 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
-from openai import OpenAI
+import os, re, requests
+
+# Optional: adjust these if running Ollama elsewhere
+OLLAMA_URL = "http://localhost:11434/v1/chat/completions"
+MODEL = "gpt-oss:20b"
 
 app = Flask(__name__)
 CORS(app)
 
-client = OpenAI(
-    base_url='http://localhost:11434/v1',
-    api_key='ollama',
-)
 
-@app.route('/chat', methods=['POST'])
+# --- Helpers -----------------------------------------------------------------
+def find_weather_city(text: str) -> str | None:
+    """Extract a city name from prompts like 'weather in Austin'."""
+    match = re.search(r"\bweather\b.*?\b(?:in|at|for)\b\s+([A-Za-z .,'-]+)", text, flags=re.I)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def get_weather_card(city: str):
+    """Fetch weather data from Open-Meteo and format a UI card payload."""
+    geo = requests.get(
+        "https://geocoding-api.open-meteo.com/v1/search",
+        params={"name": city, "count": 1},
+        timeout=10,
+    )
+    geo.raise_for_status()
+    results = geo.json().get("results") or []
+    if not results:
+        return None
+    lat = results[0]["latitude"]
+    lon = results[0]["longitude"]
+    resolved = f"{results[0]['name']}, {results[0].get('admin1', '') or results[0].get('country_code', '')}".strip(", ")
+
+    weather = requests.get(
+        "https://api.open-meteo.com/v1/forecast",
+        params={
+            "latitude": lat,
+            "longitude": lon,
+            "current": "temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,weather_code",
+            "daily": "temperature_2m_max,temperature_2m_min,uv_index_max",
+            "timezone": "auto",
+        },
+        timeout=10,
+    )
+    weather.raise_for_status()
+    data = weather.json()
+    current = data.get("current", {})
+    daily = data.get("daily", {})
+
+    code = int(current.get("weather_code", 0))
+    label = WEATHER_CODES.get(code, "Unknown")
+    return {
+        "type": "weather",
+        "location": resolved,
+        "temperature": current.get("temperature_2m"),
+        "feelsLike": current.get("apparent_temperature"),
+        "humidity": current.get("relative_humidity_2m"),
+        "wind": current.get("wind_speed_10m"),
+        "condition": label,
+        "icon": WEATHER_ICONS.get(code, "🌡️"),
+        "high": (daily.get("temperature_2m_max") or [None])[0],
+        "low": (daily.get("temperature_2m_min") or [None])[0],
+        "uv": (daily.get("uv_index_max") or [None])[0],
+    }
+
+
+WEATHER_CODES = {
+    0: "Clear sky",
+    1: "Mainly clear",
+    2: "Partly cloudy",
+    3: "Overcast",
+    45: "Fog",
+    48: "Depositing rime fog",
+    51: "Light drizzle",
+    53: "Drizzle",
+    55: "Dense drizzle",
+    61: "Light rain",
+    63: "Rain",
+    65: "Heavy rain",
+    71: "Light snow",
+    73: "Snow",
+    75: "Heavy snow",
+    80: "Rain showers",
+    81: "Heavy showers",
+    82: "Violent showers",
+    95: "Thunderstorm",
+    96: "Thunderstorm w/ hail",
+    99: "Thunderstorm w/ heavy hail",
+}
+
+
+WEATHER_ICONS = {
+    0: "☀️",
+    1: "🌤️",
+    2: "⛅",
+    3: "☁️",
+    45: "🌫️",
+    48: "🌫️",
+    51: "🌦️",
+    53: "🌦️",
+    55: "🌧️",
+    61: "🌦️",
+    63: "🌧️",
+    65: "🌧️",
+    71: "🌨️",
+    73: "❄️",
+    75: "❄️",
+    80: "🌦️",
+    81: "🌧️",
+    82: "⛈️",
+    95: "⛈️",
+    96: "⛈️",
+    99: "⛈️",
+}
+
+
+# --- Routes ------------------------------------------------------------------
+@app.post("/chat")
 def chat():
-    user_message = request.json.get('message')
-    if not user_message:
-        return jsonify({'error': 'Message is required'}), 400
-    try:
-        response = client.chat.completions.create(
-            model='gpt-oss:20b',
-            messages=[{'role': 'user', 'content': user_message}],
-        )
-        return jsonify({'reply': response.choices[0].message['content']})
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    payload = request.get_json(silent=True) or {}
+    text = (payload.get("message") or "").strip()
+    if not text:
+        return jsonify({"error": "Message is required"}), 400
 
-if __name__ == '__main__':
-    app.run(debug=True, port=5000)
+    city = find_weather_city(text)
+    if city:
+        try:
+            card = get_weather_card(city)
+            if not card:
+                return jsonify({"reply": f"Sorry, I couldn't find weather for '{city}'."})
+            reply = (
+                f"{card['icon']} {card['location']}: {card['condition']}. "
+                f"{round(card['temperature'])}°C feels {round(card['feelsLike'])}°C. "
+                f"H:{round(card['high'])}° / L:{round(card['low'])}°  •  "
+                f"Humidity {round(card['humidity'])}%  •  Wind {round(card['wind'])} km/h."
+            )
+            return jsonify({"reply": reply, "ui": card})
+        except Exception as exc:
+            return jsonify({"error": f"Weather lookup failed: {exc}"}), 500
+
+    try:
+        resp = requests.post(
+            OLLAMA_URL,
+            headers={"Authorization": "Bearer ollama", "Content-Type": "application/json"},
+            json={"model": MODEL, "messages": [{"role": "user", "content": text}]},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        reply = resp.json()["choices"][0]["message"]["content"]
+        return jsonify({"reply": reply})
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+
+
+@app.get("/health")
+def health():
+    return jsonify({"status": "ok", "model": MODEL})
+
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5000, debug=True)
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ flask
 openai
 flask-cors
 python-dotenv
+requests>=2.32

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -59,3 +59,41 @@
   border-radius: 20px;
   cursor: pointer;
 }
+
+/* Weather card styles */
+.weather-card {
+  display: grid;
+  grid-template-columns: 1fr auto 1.2fr;
+  gap: 14px;
+  border: 1px solid #ccc;
+  background: #f9f9f9;
+  border-radius: 16px;
+  padding: 14px;
+  margin: 4px 0;
+}
+.wc-left { display: flex; align-items: center; gap: 10px; }
+.wc-icon { font-size: 28px; }
+.wc-location { font-weight: 700; }
+.wc-cond { color: #666; font-size: 13px; }
+
+.wc-main {
+  display: grid;
+  place-items: center;
+  border-left: 1px dashed #ccc;
+  border-right: 1px dashed #ccc;
+  padding: 0 14px;
+}
+.wc-temp { font-size: 34px; font-weight: 800; letter-spacing: 0.5px; }
+.wc-feels { font-size: 12px; color: #666; }
+
+.wc-right { display: grid; gap: 6px; font-size: 13px; }
+.legend { display: flex; gap: 6px; margin-top: 6px; }
+.chip {
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid #ccc;
+}
+.chip.good { background: rgba(16,185,129,.18); }
+.chip.fair { background: rgba(59,130,246,.18); }
+.chip.poor { background: rgba(244,63,94,.18); }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,50 +1,105 @@
 import React, { useState } from 'react'
 import './App.css'
 
-function App() {
+const API_URL = import.meta.env.VITE_API_URL || 'http://127.0.0.1:5000'
+
+export default function App() {
   const [input, setInput] = useState('')
   const [messages, setMessages] = useState([
-    { text: 'Hello! How can I help you today?', sender: 'bot' }
+    { id: 0, type: 'text', text: 'Hello! Ask me for weather (e.g., "weather in Houston").', sender: 'bot' }
   ])
+  const [loading, setLoading] = useState(false)
 
   const handleSend = async () => {
-    if (input.trim()) {
-      const userMessage = { text: input, sender: 'user' }
-      setMessages(prev => [...prev, userMessage])
+    const text = input.trim()
+    if (!text || loading) return
+    setInput('')
 
-      const response = await fetch('http://localhost:5000/chat', {
+    setMessages(prev => [...prev, { id: Date.now(), type: 'text', text, sender: 'user' }])
+    setLoading(true)
+    try {
+      const res = await fetch(`${API_URL}/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: input })
+        body: JSON.stringify({ message: text })
       })
-      const data = await response.json()
-      const botMessage = { text: data.reply, sender: 'bot' }
-      setMessages(prev => [...prev, botMessage])
-      setInput('')
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Request failed')
+
+      if (data.reply) {
+        setMessages(prev => [...prev, { id: Date.now() + 1, type: 'text', text: data.reply, sender: 'bot' }])
+      }
+      if (data.ui?.type === 'weather') {
+        setMessages(prev => [...prev, { id: Date.now() + 2, type: 'card', sender: 'bot', card: data.ui }])
+      }
+    } catch (e) {
+      setMessages(prev => [...prev, { id: Date.now() + 3, type: 'text', text: '⚠️ ' + e.message, sender: 'bot' }])
+    } finally {
+      setLoading(false)
     }
   }
 
   return (
     <div className="App">
       <div className="chat-window">
-        {messages.map((msg, index) => (
-          <div key={index} className={`message ${msg.sender}`}>
-            {msg.text}
-          </div>
-        ))}
+        {messages.map(msg =>
+          msg.type === 'card' ? (
+            <WeatherCard key={msg.id} data={msg.card} />
+          ) : (
+            <div key={msg.id} className={`message ${msg.sender}`}>
+              {msg.text}
+            </div>
+          )
+        )}
+        {loading && <div className="message bot">…</div>}
       </div>
       <div className="chat-input">
         <input
           type="text"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyPress={(e) => e.key === 'Enter' && handleSend()}
+          onChange={e => setInput(e.target.value)}
+          onKeyPress={e => e.key === 'Enter' && handleSend()}
           placeholder="Type a message..."
         />
-        <button onClick={handleSend}>Send</button>
+        <button onClick={handleSend} disabled={loading}>Send</button>
       </div>
     </div>
   )
 }
 
-export default App
+function WeatherCard({ data }) {
+  const { location, icon, condition, temperature, feelsLike, high, low, humidity, wind, uv } = data || {}
+  return (
+    <div className="weather-card">
+      <div className="wc-left">
+        <div className="wc-icon">{icon || '🌡️'}</div>
+        <div>
+          <div className="wc-location">{location}</div>
+          <div className="wc-cond">{condition}</div>
+        </div>
+      </div>
+      <div className="wc-main">
+        <div className="wc-temp">{Math.round(temperature)}°</div>
+        <div className="wc-feels">Feels {Math.round(feelsLike)}°</div>
+      </div>
+      <div className="wc-right">
+        <div>H:{Math.round(high)}° / L:{Math.round(low)}°</div>
+        <div>Humidity: {Math.round(humidity)}%</div>
+        <div>Wind: {Math.round(wind)} km/h</div>
+        <div>UV: {uv ?? '—'}</div>
+        <Legend />
+      </div>
+    </div>
+  )
+}
+
+function Legend() {
+  return (
+    <div className="legend">
+      <span className="chip good">Good</span>
+      <span className="chip fair">Fair</span>
+      <span className="chip poor">Poor</span>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- support weather lookups and UI card responses in Flask backend
- render weather card and legend on the frontend with env-based API URL
- add requests dependency

## Testing
- `pytest`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae18685db08326980ef795a16aad29