### PR TITLE
feat: add weather card support and math rendering

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ flask
 openai
 flask-cors
 python-dotenv
+requests>=2.32

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,13 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-markdown": "^8.0.7",
+    "remark-math": "^5.1.1",
+    "rehype-katex": "^7.0.0",
+    "remark-gfm": "^3.0.1",
+    "katex": "^0.16.9",
+    "react-syntax-highlighter": "^15.5.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,61 +1,230 @@
-.App {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  width: 100%;
-  max-width: 600px;
-  margin: auto;
-  border: 1px solid #ccc;
-  box-shadow: 0 0 10px rgba(0,0,0,0.1);
+:root {
+  --bg: #0b0f14;
+  --panel: rgba(255,255,255,0.06);
+  --panel-strong: rgba(255,255,255,0.12);
+  --text: #eaeef3;
+  --muted: #a6b0c0;
+  --accent: #6ea8fe;
+  --success: #6ee7b7;
+  --danger: #ef4444;
+  --radius: 16px;
 }
+
+* { box-sizing: border-box; }
+html, body, #root { height: 100%; }
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial;
+  color: var(--text);
+  background:
+    radial-gradient(1200px 600px at -10% -10%, #1a293d 0%, transparent 50%),
+    radial-gradient(1000px 800px at 120% -20%, #2a1d3a 0%, transparent 50%),
+    linear-gradient(180deg, #0b0f14 0%, #0a0d12 100%);
+}
+
+.page {
+  display: grid;
+  place-items: center;
+  min-height: 100%;
+  padding: 24px;
+}
+
+.card {
+  width: 100%;
+  max-width: 820px;
+  background: var(--panel);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--panel-strong);
+  border-radius: calc(var(--radius) + 4px);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.45);
+  display: grid;
+  grid-template-rows: auto 1fr auto auto;
+  overflow: hidden;
+}
+
+.header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--panel-strong);
+  background: linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0));
+}
+
+.brand {
+  display: inline-flex; gap: 10px; align-items: center; font-weight: 600;
+}
+.brand svg { color: var(--success); }
+
+.actions { display: flex; gap: 8px; }
 
 .chat-window {
-  flex-grow: 1;
-  padding: 20px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+  padding: 18px;
+  display: flex; flex-direction: column; gap: 12px;
+  overflow: auto;
 }
 
-.message {
-  padding: 10px 15px;
+.row { display: flex; gap: 10px; align-items: flex-end; }
+.row.left { justify-content: flex-start; }
+.row.right { justify-content: flex-end; }
+
+.bubble {
+  max-width: min(700px, 80%);
+  padding: 12px 14px;
   border-radius: 18px;
-  max-width: 80%;
-  word-wrap: break-word;
+  position: relative;
+  border: 1px solid var(--panel-strong);
+  line-height: 1.45;
+}
+.bubble .timestamp {
+  font-size: 11px; color: var(--muted); margin-top: 6px; text-align: right;
 }
 
-.user {
-  background-color: #007bff;
-  color: white;
-  align-self: flex-end;
+.bubble.user {
+  color: #091116;
+  background: linear-gradient(120deg, #b5d2ff, #77b2ff 60%, #6ee7b7);
+  border-color: transparent;
+  box-shadow: 0 6px 20px rgba(110, 232, 183, 0.2);
 }
 
-.bot {
-  background-color: #f1f0f0;
-  color: black;
-  align-self: flex-start;
+.bubble.bot {
+  background: rgba(255,255,255,0.06);
 }
 
-.chat-input {
-  display: flex;
-  padding: 10px;
-  border-top: 1px solid #ccc;
+.avatar {
+  width: 34px; height: 34px; border-radius: 50%;
+  display: grid; place-items: center;
+  border: 1px solid var(--panel-strong);
+}
+.avatar.user { color: #0b0f14; background: #c9e2ff; }
+.avatar.bot { color: #86efac; background: rgba(134,239,172,0.12); }
+
+.typing {
+  width: 70px; display: flex; gap: 6px; align-items: center;
+}
+.typing span {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: #cbd5e1; opacity: 0.6; animation: bounce 1.3s infinite;
+}
+.typing .dot2 { animation-delay: .15s; }
+.typing .dot3 { animation-delay: .3s; }
+
+@keyframes bounce {
+  0%, 80%, 100% { transform: translateY(0); opacity: .5; }
+  40% { transform: translateY(-6px); opacity: 1; }
 }
 
-.chat-input input {
-  flex-grow: 1;
-  border: 1px solid #ccc;
-  border-radius: 20px;
-  padding: 10px;
-  margin-right: 10px;
+.composer {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  padding: 12px;
+  border-top: 1px solid var(--panel-strong);
+  background: linear-gradient(180deg, rgba(255,255,255,0), rgba(255,255,255,0.05));
 }
 
-.chat-input button {
-  border: none;
-  background-color: #007bff;
-  color: white;
-  padding: 10px 20px;
-  border-radius: 20px;
+.composer textarea {
+  resize: none; overflow: auto;
+  font: inherit; color: var(--text);
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--panel-strong);
+  border-radius: 12px;
+  padding: 12px 14px;
+  min-height: 48px;
+}
+
+.btn {
+  height: 48px; padding: 0 16px; border-radius: 12px;
+  border: 1px solid var(--panel-strong);
+  background: rgba(255,255,255,0.06); color: var(--text);
+  font-weight: 600; letter-spacing: 0.2px;
   cursor: pointer;
 }
+.btn.primary {
+  background: linear-gradient(120deg, #60a5fa, #34d399);
+  color: #03121a; border: none;
+}
+.btn:disabled { opacity: 0.6; cursor: not-allowed; }
+.btn.ghost { background: transparent; }
+
+.error {
+  color: white; background: linear-gradient(90deg, #ef4444, #f97316);
+  padding: 8px 12px; margin: 8px 12px; border-radius: 10px; font-weight: 600;
+}
+
+.meta {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px; color: var(--muted);
+  padding: 8px 12px 14px;
+}
+.meta .dot {
+  width: 8px; height: 8px; border-radius: 50%; background: #10b981;
+}
+
+/* Inline code styling */
+.inline-code {
+  padding: 0.15rem 0.33rem;
+  border-radius: 6px;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.92em;
+}
+
+/* Fenced code blocks */
+.code-block {
+  border-radius: 10px;
+  overflow-x: auto;
+}
+
+/* KaTeX tweaks */
+.katex-display {
+  margin: 8px 0;
+}
+.katex {
+  font-size: 1.02em;
+}
+
+/* Markdown polish inside bubbles */
+.content h1, .content h2, .content h3 { margin: 8px 0 6px; }
+.content p { margin: 6px 0; }
+.content ul, .content ol { margin: 6px 0; padding-left: 1.2rem; }
+.content blockquote {
+  margin: 8px 0; padding: 6px 10px;
+  border-left: 3px solid var(--panel-strong);
+  background: rgba(255,255,255,0.05);
+}
+
+/* Tables like in your screenshot */
+.content table, .md-table { width: 100%; border-collapse: collapse; margin: 10px 0; }
+.content th, .content td, .md-th, .md-td {
+  border: 1px solid var(--panel-strong);
+  padding: 8px 10px; vertical-align: top;
+}
+.content th, .md-th { background: rgba(255,255,255,0.08); text-align: left; }
+
+/* Weather card styles */
+.weather-card {
+  display: grid;
+  grid-template-columns: 1fr auto 1.2fr;
+  gap: 14px;
+  border: 1px solid var(--panel-strong);
+  background: rgba(255,255,255,0.06);
+  border-radius: 16px;
+  padding: 14px;
+  margin: 4px 0;
+}
+.wc-left { display: flex; align-items: center; gap: 10px; }
+.wc-icon { font-size: 28px; }
+.wc-location { font-weight: 700; }
+.wc-cond { color: var(--muted); font-size: 13px; }
+
+.wc-main { display: grid; place-items: center; border-left: 1px dashed rgba(255,255,255,0.15); border-right: 1px dashed rgba(255,255,255,0.15); padding: 0 14px; }
+.wc-temp { font-size: 34px; font-weight: 800; letter-spacing: 0.5px; }
+.wc-feels { font-size: 12px; color: var(--muted); }
+
+.wc-right { display: grid; gap: 6px; font-size: 13px; }
+.legend { display: flex; gap: 6px; margin-top: 6px; }
+.chip { padding: 3px 8px; border-radius: 999px; font-size: 11px; border: 1px solid var(--panel-strong); }
+.chip.good { background: rgba(16,185,129,.18); }
+.chip.fair { background: rgba(59,130,246,.18); }
+.chip.poor { background: rgba(244,63,94,.18); }
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,50 +1,326 @@
-import React, { useState } from 'react'
-import './App.css'
+import React, { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkMath from "remark-math";
+import remarkGfm from "remark-gfm";
+import rehypeKatex from "rehype-katex";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import "katex/dist/katex.min.css";
+import "./App.css";
 
-function App() {
-  const [input, setInput] = useState('')
-  const [messages, setMessages] = useState([
-    { text: 'Hello! How can I help you today?', sender: 'bot' }
-  ])
+const API_URL = import.meta.env.VITE_API_URL || "http://127.0.0.1:5000";
 
-  const handleSend = async () => {
-    if (input.trim()) {
-      const userMessage = { text: input, sender: 'user' }
-      setMessages(prev => [...prev, userMessage])
-
-      const response = await fetch('http://localhost:5000/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: input })
-      })
-      const data = await response.json()
-      const botMessage = { text: data.reply, sender: 'bot' }
-      setMessages(prev => [...prev, botMessage])
-      setInput('')
-    }
-  }
-
-  return (
-    <div className="App">
-      <div className="chat-window">
-        {messages.map((msg, index) => (
-          <div key={index} className={`message ${msg.sender}`}>
-            {msg.text}
-          </div>
-        ))}
-      </div>
-      <div className="chat-input">
-        <input
-          type="text"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyPress={(e) => e.key === 'Enter' && handleSend()}
-          placeholder="Type a message..."
-        />
-        <button onClick={handleSend}>Send</button>
-      </div>
-    </div>
-  )
+function normalizeLatexDelimiters(s) {
+  // \[ ... \] → $$ ... $$
+  s = s.replace(/\\\[(.*?)\\\]/gs, (_m, inner) => `$$\n${inner.trim()}\n$$`);
+  // \( ... \) → $ ... $
+  s = s.replace(/\\\((.*?)\\\)/gs, (_m, inner) => `$${inner.trim()}$`);
+  // one-line [ ... ] → $$ ... $$
+  s = s.replace(/^\s*\[(.+?)\]\s*$/gms, (_m, inner) => `$$\n${inner.trim()}\n$$`);
+  // cleanup commas around braces
+  s = s.replace(/\{,\s*/g, "{").replace(/,\s*\}/g, "}");
+  return s;
 }
 
-export default App
+export default function App() {
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState([
+    {
+      id: 0,
+      type: "text",
+      text: "Hello! Ask me for weather (e.g., \u201cweather in Houston\u201d).",
+      sender: "bot",
+      ts: Date.now(),
+    },
+  ]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const endRef = useRef(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  const handleSend = async () => {
+    const text = input.trim();
+    if (!text || loading) return;
+    setError("");
+    setInput("");
+
+    const userMsg = {
+      id: Date.now(),
+      type: "text",
+      text,
+      sender: "user",
+      ts: Date.now(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setLoading(true);
+
+    try {
+      const res = await fetch(`${API_URL}/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: text }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Request failed");
+
+      if (data.reply) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now() + 1,
+            type: "text",
+            text: String(data.reply ?? ""),
+            sender: "bot",
+            ts: Date.now(),
+          },
+        ]);
+      }
+      if (data.ui?.type === "weather") {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now() + 2,
+            type: "card",
+            sender: "bot",
+            ts: Date.now(),
+            card: data.ui,
+          },
+        ]);
+      }
+    } catch (e) {
+      setError(e.message || "Something went wrong");
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now() + 3,
+          type: "text",
+          text: "\u26a0\ufe0f " + (e.message || "Error"),
+          sender: "bot",
+          ts: Date.now(),
+        },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onKeyDown = (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  const clearChat = () =>
+    setMessages([
+      {
+        id: 0,
+        type: "text",
+        text: "New chat started. Ask me anything!",
+        sender: "bot",
+        ts: Date.now(),
+      },
+    ]);
+
+  return (
+    <div className="page">
+      <div className="card">
+        <header className="header">
+          <div className="brand">
+            <SparklesIcon />
+            <span>Local Chat (Ollama)</span>
+          </div>
+          <div className="actions">
+            <button className="btn ghost" onClick={clearChat} title="Clear chat">
+              Clear
+            </button>
+          </div>
+        </header>
+
+        <main className="chat-window">
+          {messages.map((m) =>
+            m.type === "card" ? (
+              <WeatherCard key={m.id} data={m.card} />
+            ) : (
+              <Message key={m.id} text={m.text} sender={m.sender} ts={m.ts} />
+            )
+          )}
+          {loading && <Typing />}
+          <div ref={endRef} />
+        </main>
+
+        <footer className="composer">
+          <textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Type a message… (Enter to send, Shift+Enter for newline)"
+            rows={1}
+          />
+          <button
+            className="btn primary"
+            onClick={handleSend}
+            disabled={loading || !input.trim()}
+          >
+            {loading ? "Sending…" : "Send"}
+          </button>
+        </footer>
+
+        {error && <div className="error">{error}</div>}
+
+        <div className="meta">
+          <span className="dot" />
+          Backend: <code>{API_URL}</code>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Message({ text, sender, ts }) {
+  const isUser = sender === "user";
+  const normalized = normalizeLatexDelimiters(text);
+  return (
+    <div className={`row ${isUser ? "right" : "left"}`}>
+      {!isUser && <AvatarBot />}
+      <div className={`bubble ${isUser ? "user" : "bot"}`}>
+        <div className="content">
+          <ReactMarkdown
+            remarkPlugins={[[remarkMath, { singleDollarTextMath: true }], remarkGfm]}
+            rehypePlugins={[[rehypeKatex, { throwOnError: false, strict: "ignore" }]]}
+            components={{
+              code({ inline, className, children, ...props }) {
+                const lang = /language-(\w+)/.exec(className || "")?.[1] || "text";
+                return inline ? (
+                  <code className="inline-code" {...props}>{children}</code>
+                ) : (
+                  <SyntaxHighlighter language={lang} PreTag="div" className="code-block">
+                    {String(children).replace(/\n$/, "")}
+                  </SyntaxHighlighter>
+                );
+              },
+              table({ children }) {
+                return <table className="md-table">{children}</table>;
+              },
+              th({ children }) {
+                return <th className="md-th">{children}</th>;
+              },
+              td({ children }) {
+                return <td className="md-td">{children}</td>;
+              },
+            }}
+          >
+            {normalized}
+          </ReactMarkdown>
+        </div>
+        <div className="timestamp">{new Date(ts).toLocaleTimeString()}</div>
+      </div>
+      {isUser && <AvatarUser />}
+    </div>
+  );
+}
+
+function Typing() {
+  return (
+    <div className="row left">
+      <AvatarBot />
+      <div className="bubble bot typing">
+        <span className="dot1" />
+        <span className="dot2" />
+        <span className="dot3" />
+      </div>
+    </div>
+  );
+}
+
+function AvatarBot() {
+  return (
+    <div className="avatar bot">
+      <SparklesIcon />
+    </div>
+  );
+}
+
+function AvatarUser() {
+  return (
+    <div className="avatar user">
+      <UserIcon />
+    </div>
+  );
+}
+
+function SparklesIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" role="img" aria-label="bot">
+      <path
+        d="M5 3l1.5 4.5L11 9 6.5 10.5 5 15 3.5 10.5  -1 9 3.5 7.5 5 3zm10 3l2 6 6 2-6 2-2 6-2-6-6-2 6-2 2-6z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function UserIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" role="img" aria-label="you">
+      <path
+        d="M12 12a5 5 0 100-10 5 5 0 000 10zm-8 9a8 8 0 1116 0v1H4v-1z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function WeatherCard({ data }) {
+  const {
+    location,
+    icon,
+    condition,
+    temperature,
+    feelsLike,
+    high,
+    low,
+    humidity,
+    wind,
+    uv,
+    units,
+  } = data || {};
+  const t = units?.temp || "°C";
+  const w = units?.wind || "km/h";
+  const d = (v) => (Number.isFinite(v) ? Math.round(v) : "—");
+  return (
+    <div className="weather-card">
+      <div className="wc-left">
+        <div className="wc-icon">{icon || "🌡️"}</div>
+        <div>
+          <div className="wc-location">{location}</div>
+          <div className="wc-cond">{condition}</div>
+        </div>
+      </div>
+      <div className="wc-main">
+        <div className="wc-temp">{d(temperature)}{t}</div>
+        <div className="wc-feels">Feels {d(feelsLike)}{t}</div>
+      </div>
+      <div className="wc-right">
+        <div>H:{d(high)}{t} / L:{d(low)}{t}</div>
+        <div>Humidity: {d(humidity)}%</div>
+        <div>Wind: {d(wind)} {w}</div>
+        <div>UV: {uv ?? "—"}</div>
+        <Legend />
+      </div>
+    </div>
+  );
+}
+
+function Legend() {
+  return (
+    <div className="legend">
+      <span className="chip good">Good</span>
+      <span className="chip fair">Fair</span>
+      <span className="chip poor">Poor</span>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- support weather lookups and UI card responses in Flask backend
- render weather cards and Markdown math in the React frontend with Katex styling
- add requests, react-markdown, and math dependencies
- guide the LLM to answer in Markdown and highlight code blocks in the UI
- normalize LaTeX delimiters and surface temperature/wind units for accurate card rendering

## Testing
- `pytest`
- `npm --prefix frontend install` *(fails: 403 Forbidden for katex)*
- `npm --prefix frontend run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae18685db08326980ef795a16aad29